### PR TITLE
Make full build (`nixci`) work

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,14 +21,16 @@
       # Deploy
       default = {
         type = "app";
-        program = nixpkgs.lib.getExe deploy-rs;
+        program = nixpkgs.lib.getExe deploy-rs.packages.x86_64-linux.deploy-rs;
       };
     };
     nixosConfigurations.nixos-remote-01 = nixpkgs.lib.nixosSystem {
-      system = "x86_64-linux";
       modules = [
         disko.nixosModules.disko
         ./nix/configuration.nix
+        {
+          nixpkgs.hostPlatform = "x86_64-linux";
+        }
       ];
     };
   };


### PR DESCRIPTION
2851f8d5596f75c47d344939928d5e1049261bc2 revealed that our flake wasn't building fully in the first place.